### PR TITLE
feat(src): add page navigation to main section

### DIFF
--- a/docs/pages/basics/commands.md
+++ b/docs/pages/basics/commands.md
@@ -24,6 +24,8 @@ malta preview
 malta preview --port 5000
 ```
 
+**Note**: It's important to ensure you build your project before running the preview server to ensure that the generated site reflects the latest changes.
+
 ### Options
 
 - `--port` (`-p`): Localhost port (number - `3000` by default)

--- a/src/commands/build/assets/main.css
+++ b/src/commands/build/assets/main.css
@@ -1,184 +1,239 @@
 .hidden {
-    display: none !important;
+  display: none !important;
 }
 
 body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
-        Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-    line-height: 1.5;
-    tab-size: 4;
-    padding: 0;
-    margin: 0;
-    color: rgb(44, 44, 44);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
+    Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  line-height: 1.5;
+  tab-size: 4;
+  padding: 0;
+  margin: 0;
+  color: rgb(44, 44, 44);
 }
 
 code {
-    font-family: "SF Mono", SFMono-Regular, ui-monospace, "DejaVu Sans Mono",
-        Menlo, Consolas, monospace;
-    font-size: 0.875em;
+  font-family: "SF Mono", SFMono-Regular, ui-monospace, "DejaVu Sans Mono",
+    Menlo, Consolas, monospace;
+  font-size: 0.875em;
 }
 
 img {
-    max-width: 100%;
-    height: auto;
-    object-fit: cover;
+  max-width: 100%;
+  height: auto;
+  object-fit: cover;
 }
 
 #mobile-top {
-    border-bottom: 1px solid rgb(221, 221, 221);
-    padding-left: 1rem;
-    padding-right: 1rem;
-    padding-top: 0.375rem;
-    padding-bottom: 0.25rem;
+  border-bottom: 1px solid rgb(221, 221, 221);
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.375rem;
+  padding-bottom: 0.25rem;
 }
 
 @media (min-width: 640px) {
-    #mobile-top {
-        padding-left: 2rem;
-        padding-right: 2rem;
-    }
+  #mobile-top {
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
 }
 
 @media (min-width: 960px) {
-    #mobile-top {
-        display: none;
-    }
+  #mobile-top {
+    display: none;
+  }
 }
 
 #mobile-top-container {
-    max-width: 64rem;
-    width: 100%;
-    margin-left: auto;
-    margin-right: auto;
+  max-width: 64rem;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 #mobile-header {
-    display: flex;
-    place-items: center;
-    place-content: space-between;
+  display: flex;
+  place-items: center;
+  place-content: space-between;
 }
 
 #toggle-mobile-menu-button {
-    height: 2rem;
-    width: 2rem;
-    padding: 0.5rem;
-    border: 0;
-    background-color: transparent;
-    cursor: pointer;
+  height: 2rem;
+  width: 2rem;
+  padding: 0.5rem;
+  border: 0;
+  background-color: transparent;
+  cursor: pointer;
 }
 
 #mobile-menu-nav {
-    width: 100%;
-    padding-top: 1.125rem;
-    padding-bottom: 0.5rem;
-    display: flex;
-    flex-direction: column;
-    row-gap: 1rem;
+  width: 100%;
+  padding-top: 1.125rem;
+  padding-bottom: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  row-gap: 1rem;
 }
 
 #content {
-    padding-left: 1rem;
-    padding-right: 1rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 @media (min-width: 640px) {
-    #content {
-        padding-left: 2rem;
-        padding-right: 2rem;
-    }
+  #content {
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
 }
 
 #content-container {
-    margin-left: auto;
-    margin-right: auto;
-    max-width: 64rem;
-    width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 64rem;
+  width: 100%;
 }
 
 #sidebar {
-    position: fixed;
-    height: 100vh;
-    width: 14rem;
-    padding-top: 3rem;
-    display: none;
+  position: fixed;
+  height: 100vh;
+  width: 14rem;
+  padding-top: 3rem;
+  display: none;
 }
 
 @media (min-width: 960px) {
-    #sidebar {
-        display: flex;
-        flex-direction: column;
-        box-sizing: border-box;
-    }
+  #sidebar {
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
+  }
 }
 
 #sidebar-nav {
-    margin-top: 1.125rem;
-    display: flex;
-    flex-direction: column;
-    row-gap: 1rem;
-    overflow: auto;
-    padding-bottom: 1rem;
-    overscroll-behavior: contain;
+  margin-top: 1.125rem;
+  display: flex;
+  flex-direction: column;
+  row-gap: 1rem;
+  overflow: auto;
+  padding-bottom: 1rem;
+  overscroll-behavior: contain;
 }
 
 main {
-    overflow: hidden;
-    padding-bottom: 6rem;
-    padding-top: 2rem;
+  overflow: hidden;
+  padding-bottom: 6rem;
+  padding-top: 2rem;
+}
+
+.main-nav-link-container {
+  display: grid;
+  grid-template-columns: 1fr;
+  align-items: center;
+  gap: 24px;
+}
+
+.main-nav-link {
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  border: solid 1px rgb(200, 200, 200);
+  display: flex;
+  flex-direction: column;
+  transition: all 250ms;
+  color: rgb(44, 44, 44);
+}
+
+.main-nav-link:hover {
+  text-decoration: none;
+  border-color: rgb(77, 107, 255);
+}
+
+.main-nav-link:hover .title {
+  color: rgb(77, 107, 255);
+}
+
+.main-nav-link.previous {
+  text-align: left;
+}
+
+.main-nav-link.next {
+  text-align: right;
+}
+
+.main-nav-link .description {
+  font-size: 0.75rem;
+}
+
+.main-nav-link .title {
+  font-size: 0.875rem;
+}
+
+@media (min-width: 768px) {
+  .main-nav-link-container {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    align-items: center;
+    gap: 24px;
+  }
+
+  .main-nav-link.next {
+    grid-column-start: 2;
+  }
 }
 
 @media (min-width: 960px) {
-    main {
-        padding-top: 3rem;
-        margin-left: 14rem;
-        padding-left: 1rem;
-    }
+  main {
+    padding-top: 3rem;
+    margin-left: 14rem;
+    padding-left: 1rem;
+  }
 }
 
 .nav-section-title {
-    margin-top: 0;
-    margin-bottom: 0.25rem;
-    font-weight: 500;
-    font-size: 0.875rem;
+  margin-top: 0;
+  margin-bottom: 0.25rem;
+  font-weight: 500;
+  font-size: 0.875rem;
 }
 
 .nav-section-links-list {
-    margin: 0;
-    padding: 0;
-    list-style-type: none;
-    font-size: 0.875rem;
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+  font-size: 0.875rem;
 }
 
 .nav-section-links-list-item {
-    margin-top: 0.25rem;
+  margin-top: 0.25rem;
 }
 
 .nav-section-link {
-    color: rgb(110, 110, 110);
-    text-decoration: none;
+  color: rgb(110, 110, 110);
+  text-decoration: none;
 }
 
 .current-nav-section-link {
-    color: rgb(77, 107, 255);
-    text-decoration: none;
+  color: rgb(77, 107, 255);
+  text-decoration: none;
 }
 
 .nav-section-link:hover,
 .current-nav-section-link:hover {
-    text-decoration: underline;
+  text-decoration: underline;
 }
 
 #mobile-header-title {
-    color: inherit;
-    text-decoration: none;
-    font-weight: 500;
-    font-size: 1.25rem;
+  color: inherit;
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 1.25rem;
 }
 
 #sidebar-title {
-    color: inherit;
-    text-decoration: none;
-    font-weight: 500;
-    font-size: 1.5rem;
-    line-height: 1;
+  color: inherit;
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 1.5rem;
+  line-height: 1;
 }

--- a/src/commands/build/assets/main.css
+++ b/src/commands/build/assets/main.css
@@ -127,6 +127,13 @@ main {
   padding-top: 2rem;
 }
 
+.main-section-title {
+  color: rgb(110, 110, 110);
+  margin: 0;
+  font-size: 16px;
+  font-weight: 400;
+}
+
 .main-nav-link-container {
   display: grid;
   grid-template-columns: 1fr;

--- a/src/commands/build/assets/template.html
+++ b/src/commands/build/assets/template.html
@@ -117,6 +117,7 @@
           </nav>
         </aside>
         <main>
+          <h4 class="main-section-title">{{.SectionTitle}}</h4>
           {{.Markdown}}
           <br />
           {{if or (ne .PrevNavPage.Href "") (ne .NextNavPage.Href "")}}

--- a/src/commands/build/assets/template.html
+++ b/src/commands/build/assets/template.html
@@ -77,9 +77,9 @@
                   >{{$page.Title}}</a
                 >
                 {{else}}
-                  <a href="{{$page.Href}}" class="nav-section-link"
-                    >{{$page.Title}}</a
-                  >
+                <a href="{{$page.Href}}" class="nav-section-link"
+                  >{{$page.Title}}</a
+                >
                 {{end}}
               </li>
               {{end}}
@@ -116,7 +116,25 @@
             {{end}}
           </nav>
         </aside>
-        <main>{{.Markdown}}</main>
+        <main>
+          {{.Markdown}}
+          <br />
+          {{if or (ne .PrevNavPage.Href "") (ne .NextNavPage.Href "")}}
+          <section class="main-nav-link-container">
+            {{if ne .PrevNavPage.Href ""}}
+            <a href="{{.PrevNavPage.Href}}" class="main-nav-link previous">
+              <span class="description">Previous</span>
+              <span class="title"> {{.PrevNavPage.Title}} </span>
+            </a>
+            {{end}} {{if ne .NextNavPage.Href ""}}
+            <a href="{{.NextNavPage.Href}}" class="main-nav-link next">
+              <span class="description">Next</span>
+              <span class="title">{{.NextNavPage.Title}}</span></a
+            >
+            {{end}}
+          </section>
+          {{end}}
+        </main>
       </div>
     </div>
   </body>

--- a/src/commands/build/main.go
+++ b/src/commands/build/main.go
@@ -127,35 +127,36 @@ func BuildCommand() int {
 		}
 		url := config.Domain + urlPathname
 
-		var currentNavPageHref string
-		prevNavPage := NavPage{Title:"", Href: ""}
-		nextNavPage := NavPage{Title:"", Href: ""}
+		var currentNavPageHref, currentSectionTitle string
+		prevNavPage := NavPage{Title: "", Href: ""}
+		nextNavPage := NavPage{Title: "", Href: ""}
 
 		for _, navSection := range navSections {
 			for sectionPageIndex, sectionPage := range navSection.Pages {
 				if urlPathname == sectionPage.Href || strings.HasPrefix(urlPathname, sectionPage.Href+"/") {
+					currentSectionTitle = navSection.Title
 					currentNavPageHref = sectionPage.Href
 					if sectionPageIndex == 0 && len(navSection.Pages) >= 2 {
 						// first index
 						// set next
-						if isPageLink(navSection.Pages[sectionPageIndex + 1].Href){
-							nextNavPage = navSection.Pages[sectionPageIndex + 1]
+						if isPageLink(navSection.Pages[sectionPageIndex+1].Href) {
+							nextNavPage = navSection.Pages[sectionPageIndex+1]
 						}
-					} else if sectionPageIndex > 0 && sectionPageIndex < len(navSection.Pages) - 1 {
+					} else if sectionPageIndex > 0 && sectionPageIndex < len(navSection.Pages)-1 {
 						// first index < index < last index
 						// set prev and next
-						if isPageLink(navSection.Pages[sectionPageIndex - 1].Href){
-							prevNavPage = navSection.Pages[sectionPageIndex - 1]
+						if isPageLink(navSection.Pages[sectionPageIndex-1].Href) {
+							prevNavPage = navSection.Pages[sectionPageIndex-1]
 						}
 
-						if isPageLink(navSection.Pages[sectionPageIndex + 1].Href){
-							nextNavPage = navSection.Pages[sectionPageIndex + 1]
+						if isPageLink(navSection.Pages[sectionPageIndex+1].Href) {
+							nextNavPage = navSection.Pages[sectionPageIndex+1]
 						}
-					} else if sectionPageIndex == len(navSection.Pages) - 1 && len(navSection.Pages) >= 2 {
+					} else if sectionPageIndex == len(navSection.Pages)-1 && len(navSection.Pages) >= 2 {
 						// last index
 						// set prev
-						if isPageLink(navSection.Pages[sectionPageIndex - 1].Href){
-							prevNavPage = navSection.Pages[sectionPageIndex - 1]
+						if isPageLink(navSection.Pages[sectionPageIndex-1].Href) {
+							prevNavPage = navSection.Pages[sectionPageIndex-1]
 						}
 					}
 					break
@@ -165,6 +166,7 @@ func BuildCommand() int {
 
 		err = tmpl.Execute(dstHtmlFile, Data{
 			Markdown:           template.HTML(markdownHtml),
+			SectionTitle:       currentSectionTitle,
 			Name:               config.Name,
 			Description:        config.Description,
 			Url:                url,
@@ -172,8 +174,8 @@ func BuildCommand() int {
 			Title:              matter.Title,
 			NavSections:        navSections,
 			CurrentNavPageHref: currentNavPageHref,
-			PrevNavPage: 	prevNavPage,
-			NextNavPage: 	nextNavPage,
+			PrevNavPage:        prevNavPage,
+			NextNavPage:        nextNavPage,
 		})
 		if err != nil {
 			panic(err)
@@ -186,6 +188,7 @@ func BuildCommand() int {
 	}
 	err = tmpl.Execute(notFoundDstHtmlFile, Data{
 		Markdown:           template.HTML("<h1>404 - Not found</h1><p>The page you were looking for does not exist.</p>"),
+		SectionTitle:       "",
 		Name:               config.Name,
 		Description:        config.Description,
 		Url:                config.Domain,
@@ -193,8 +196,8 @@ func BuildCommand() int {
 		Title:              "Not found",
 		NavSections:        navSections,
 		CurrentNavPageHref: "",
-		PrevNavPage: 	NavPage{Title:"", Href: ""},
-		NextNavPage: 	NavPage{Title:"", Href: ""},
+		PrevNavPage:        NavPage{Title: "", Href: ""},
+		NextNavPage:        NavPage{Title: "", Href: ""},
 	})
 	if err != nil {
 		panic(err)
@@ -222,6 +225,7 @@ func walkPagesDir(path string, info os.FileInfo, err error) error {
 
 type Data struct {
 	Markdown           template.HTML
+	SectionTitle       string
 	Title              string
 	Description        string
 	Twitter            string
@@ -229,8 +233,8 @@ type Data struct {
 	Name               string
 	NavSections        []NavSection
 	CurrentNavPageHref string
-	PrevNavPage		   NavPage
-	NextNavPage 	   NavPage
+	PrevNavPage        NavPage
+	NextNavPage        NavPage
 }
 
 type NavSection struct {


### PR DESCRIPTION
### PR Description
This PR affects 
- `src` and `docs`

This PR contains the following:
- Addition of "Previous" and "Next" buttons for easy navigation between pages (especially on mobile)
- Docs update on the need to `build` before running `preview`

I am open to any changes needed to push this PR through.

Some screenshots of the update
#### Section with previous and next
![Screenshot 2024-03-11 at 17 57 31](https://github.com/pilcrowOnPaper/malta/assets/67395687/265a6a7c-594d-4610-b0c4-c3860573199d)

#### Section with just previous and doc changes
![Screenshot 2024-03-11 at 17 58 20](https://github.com/pilcrowOnPaper/malta/assets/67395687/6eefdd6f-20af-4e16-a060-3f4690096211)
